### PR TITLE
Bump eth-account from 0.4.0 to 0.5.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ djangorestframework==3.14.0
 drf-yasg==1.21.7
 ecdsa==0.18.0
 eth-abi==2.2.0
-eth-account==0.4.0
+eth-account==0.5.9
 eth-hash==0.5.2
 eth-keyfile==0.5.1
 eth-keys==0.2.4


### PR DESCRIPTION
Bump eth-account from 0.4.0 to 0.5.9
Bumps [eth-account](https://github.com/ethereum/eth-account) from 0.4.0 to 0.5.9.
- [Changelog](https://github.com/ethereum/eth-account/blob/master/docs/release_notes.rst)
- [Commits](https://github.com/ethereum/eth-account/compare/v0.4.0...v0.5.9)

---
updated-dependencies:
- dependency-name: eth-account
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>